### PR TITLE
fix: add gpg --export fallback for keyboxd compatibility

### DIFF
--- a/crates/gpg/src/keybox.rs
+++ b/crates/gpg/src/keybox.rs
@@ -155,10 +155,17 @@ pub fn load_cert(spec: &str) -> Result<Cert> {
     tracing::debug!(spec = spec, "No matching cert in keybox, trying `gpg --export` fallback");
 
     match Command::new("gpg").args(&["--export", "-a", spec]).output() {
-      Ok(out) if !out.stdout.is_empty() => {
+      Ok(out) if out.status.success() && !out.stdout.is_empty() => {
         tracing::debug!(size = out.stdout.len(), "gpg export returned data");
         return Cert::from_bytes(&out.stdout)
           .with_context(|| format!("Failed to parse certificate exported by gpg for '{}'", spec));
+      }
+      Ok(out) if !out.status.success() => {
+        tracing::debug!(
+          status = ?out.status.code(),
+          stderr = %String::from_utf8_lossy(&out.stderr),
+          "`gpg --export` failed"
+        );
       }
       Ok(_) => {
         tracing::debug!(spec = spec, "`gpg --export` had no output we fall through to the original error.");

--- a/crates/gpg/src/keybox.rs
+++ b/crates/gpg/src/keybox.rs
@@ -5,6 +5,7 @@ use sequoia_openpgp::cert::prelude::*;
 use sequoia_openpgp::parse::Parse;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 fn gnupg_home() -> Result<PathBuf> {
   if let Ok(dir) = std::env::var("GNUPGHOME") {
@@ -151,6 +152,22 @@ pub fn load_cert(spec: &str) -> Result<Cert> {
   let matches = find_certs_in_keybox(&certs, spec);
 
   if matches.is_empty() {
+    tracing::debug!(spec = spec, "No matching cert in keybox, trying `gpg --export` fallback");
+
+    match Command::new("gpg").args(&["--export", "-a", spec]).output() {
+      Ok(out) if !out.stdout.is_empty() => {
+        tracing::debug!(size = out.stdout.len(), "gpg export returned data");
+        return Cert::from_bytes(&out.stdout)
+          .with_context(|| format!("Failed to parse certificate exported by gpg for '{}'", spec));
+      }
+      Ok(_) => {
+        tracing::debug!(spec = spec, "`gpg --export` had no output we fall through to the original error.");
+      }
+      Err(e) => {
+        tracing::debug!(error = %e, "Failed to run `gpg --export` fallback");
+      }
+    }
+
     bail!(
       "No matching certificate found for '{}'. Provide a .asc file path or import the key into your keybox.",
       spec

--- a/crates/gpg/src/keybox.rs
+++ b/crates/gpg/src/keybox.rs
@@ -152,7 +152,10 @@ pub fn load_cert(spec: &str) -> Result<Cert> {
   let matches = find_certs_in_keybox(&certs, spec);
 
   if matches.is_empty() {
-    tracing::debug!(spec = spec, "No matching cert in keybox, trying `gpg --export` fallback");
+    tracing::debug!(
+      spec = spec,
+      "No matching cert in keybox, trying `gpg --export` fallback"
+    );
 
     match Command::new("gpg").args(&["--export", "-a", spec]).output() {
       Ok(out) if out.status.success() && !out.stdout.is_empty() => {
@@ -168,7 +171,10 @@ pub fn load_cert(spec: &str) -> Result<Cert> {
         );
       }
       Ok(_) => {
-        tracing::debug!(spec = spec, "`gpg --export` had no output we fall through to the original error.");
+        tracing::debug!(
+          spec = spec,
+          "`gpg --export` had no output we fall through to the original error."
+        );
       }
       Err(e) => {
         tracing::debug!(error = %e, "Failed to run `gpg --export` fallback");


### PR DESCRIPTION
The modern versions of GnuPG (>= 2.4.1) enable use-keyboxd by default. This migrates public key management away from the legacy pubring.kbx file into an internal SQLite database managed exclusively by the keyboxd background daemon. 
Thus, because here we only read the on-disk .kbx file, it fails to find newly imported keys or smartcard certificates that are only tracked by keyboxd.
> We don't use GnuPG's keyboxd to access keybox databases. Instead, we read the certificates directly from the keybox database if we discover one.
[https://crates.io/crates/sequoia-chameleon-gnupg](source)

> This implementation is based on keybox files created by GnuPG 2.2.23 and the way they are handled by the kbxutil program from that version of GnuPG.
[https://docs.rs/sequoia-ipc/latest/sequoia_ipc/keybox/struct.Keybox.html](source)

This PR adds a fallback mechanism to the certificate loading process. If a key isn't found in the legacy keybox, the code now shells out to gpg --export -a <spec> to request the certificate directly from GnuPG's IPC/daemon. I know it isn't pretty but I don't know how to do this otherwise.

I don't know if this issue is only on my part, but without this I couldn't make my security key appear in my .kbx file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate retrieval: if a local lookup finds no matches, the system now attempts to export the certificate via GPG as a fallback. When the export succeeds and returns data, the certificate is accepted; otherwise the original “no match” outcome is preserved with additional debug details for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->