### PR TITLE
ci: gate GHCR publishing to release contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,104 @@ jobs:
       run:
         shell: nix develop --command bash -eo pipefail {0}
     permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            runs_on: ubuntu-24.04
+            platform: linux-amd64
+          - name: linux-arm64
+            runs_on: ubuntu-24.04-arm
+            platform: linux-arm64
+          - name: macos-arm64
+            runs_on: macos-26
+            platform: darwin-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Cachix
+        if: ${{ github.event_name != 'push' }}
+        uses: cachix/cachix-action@v16
+        with:
+          name: pdf-sign
+
+      - name: Cachix (trusted push)
+        if: ${{ github.event_name == 'push' }}
+        uses: cachix/cachix-action@v16
+        with:
+          name: pdf-sign
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build (flake)
+        run: |
+          nix build .#pdf-sign --out-link result
+
+      - name: Test (flake checks)
+        run: |
+          nix flake check -L
+
+      - name: Collect artifact
+        run: |
+          mkdir -p dist
+          cp -L result/bin/pdf-sign "dist/pdf-sign-${{ runner.os }}-$(uname -m)"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pdf-sign-${{ matrix.name }}
+          path: dist/*
+
+  attest-artifacts:
+    name: Attest artifact (${{ matrix.name }})
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
       id-token: write
       contents: read
       attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+          - name: linux-arm64
+          - name: macos-arm64
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pdf-sign-${{ matrix.name }}
+          path: dist
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*
+
+  publish-image:
+    name: Publish image (${{ matrix.name }})
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+    needs: build
+    runs-on: ${{ matrix.runs_on }}
+    defaults:
+      run:
+        shell: nix develop --command bash -eo pipefail {0}
+    permissions:
+      id-token: write
+      contents: read
       packages: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -52,60 +146,37 @@ jobs:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build (flake)
-        run: |
-          nix build .#pdf-sign --out-link result
-
-      - name: Test (flake checks)
-        run: |
-          nix flake check -L
-
-      - name: Collect artifact
-        run: |
-          mkdir -p dist
-          cp -L result/bin/pdf-sign "dist/pdf-sign-${{ runner.os }}-$(uname -m)"
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: dist/*
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: pdf-sign-${{ matrix.name }}
-          path: dist/*
-
-      # --- OCI image build and push (all platforms) ---
-
       - name: Build streaming image
         run: |
           nix build .#image --out-link image
 
       - name: Login to GHCR
-        if: github.event.pull_request.head.repo.fork != true
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ github.token }}
         run: |
           skopeo login ghcr.io \
-            --username "${{ github.actor }}" \
-            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --username "$GHCR_USERNAME" \
+            --password "$GHCR_TOKEN" \
             --compat-auth-file "$HOME/.docker/config.json"
 
       - name: Push image to GHCR
         id: push-image
-        if: github.event.pull_request.head.repo.fork != true
+        env:
+          GHCR_REPOSITORY: ${{ github.repository }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           printf '{"default":[{"type":"reject"}],"transports":{"docker-archive":{"":[{"type":"insecureAcceptAnything"}]},"docker":{"ghcr.io/%s":[{"type":"insecureAcceptAnything"}]}}}\n' \
-            "${{ github.repository }}" > "$RUNNER_TEMP/skopeo-policy.json"
+            "$GHCR_REPOSITORY" > "$RUNNER_TEMP/skopeo-policy.json"
           ./image | gzip --fast | skopeo \
             --policy "$RUNNER_TEMP/skopeo-policy.json" \
             copy \
             --digestfile "$RUNNER_TEMP/image-digest" \
             docker-archive:/dev/stdin \
-            "docker://$IMAGE:sha-${GITHUB_SHA::7}-${{ matrix.platform }}"
+            "docker://$IMAGE:sha-${GITHUB_SHA::7}-$PLATFORM"
           echo "digest=$(cat "$RUNNER_TEMP/image-digest")" >> "$GITHUB_OUTPUT"
 
       - name: Attest image
-        if: github.event.pull_request.head.repo.fork != true
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.IMAGE }}
@@ -114,8 +185,8 @@ jobs:
 
   docker:
     name: Docker Manifest
-    if: github.event.pull_request.head.repo.fork != true
-    needs: build
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+    needs: publish-image
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -142,10 +213,13 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Login to GHCR
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ github.token }}
         run: |
           skopeo login ghcr.io \
-            --username "${{ github.actor }}" \
-            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --username "$GHCR_USERNAME" \
+            --password "$GHCR_TOKEN" \
             --compat-auth-file "$HOME/.docker/config.json"
 
       - name: Compute tags
@@ -172,9 +246,11 @@ jobs:
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Create multi-platform manifest
+        env:
+          MANIFEST_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           SHA_SHORT="${GITHUB_SHA::7}"
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$MANIFEST_TAGS"
 
           FIRST_TAG="${TAG_ARRAY[0]}"
           EXTRA_TAGS=()
@@ -204,11 +280,13 @@ jobs:
 
       - name: Verify attestations
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_TAGS: ${{ steps.tags.outputs.tags }}
+          GHCR_REPOSITORY: ${{ github.repository }}
         run: |
           sleep 5
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$MANIFEST_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             echo "Verifying $tag..."
-            gh attestation verify "oci://$tag" --repo "${{ github.repository }}"
+            gh attestation verify "oci://$tag" --repo "$GHCR_REPOSITORY"
           done


### PR DESCRIPTION
## Summary
- gate GHCR login, image pushes, and image attestations to `push` events on `main` or `v*` tags
- skip the Docker Manifest publish job on pull requests
- use `${{ github.token }}` for workflow-token GHCR operations instead of the secrets context

## Why
Renovate PR CI is currently failing in publish-only steps. Pull requests should build/test/upload artifacts, but should not need package write credentials or GHCR login/push paths.

## Verification
- `git diff --check`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/ci.yml`
- `nix flake check --no-build -L`
- independent subagent review: approved, no blockers

## Notes
A full `nix flake check -L` was started but exceeded the 600s foreground limit while downloading/building dependencies; no syntax/evaluation failure was observed before timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release and image publishing workflow so builds and publishes now run only on main branch and version tag pushes.
  * Aligned authentication and attestation checks with the new publishing flow for more consistent CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->