### PR TITLE
ci: isolate skopeo registry config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,14 @@ jobs:
         run: |
           nix build .#image --out-link image
 
+      - name: Configure containers registry lookup
+        run: |
+          cat > "$RUNNER_TEMP/registries.conf" <<'EOF'
+          unqualified-search-registries = []
+          EOF
+          echo "CONTAINERS_REGISTRIES_CONF=$RUNNER_TEMP/registries.conf" >> "$GITHUB_ENV"
+          echo "CONTAINERS_REGISTRIES_CONF_OVERRIDE=" >> "$GITHUB_ENV"
+
       - name: Login to GHCR
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -211,6 +219,14 @@ jobs:
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Configure containers registry lookup
+        run: |
+          cat > "$RUNNER_TEMP/registries.conf" <<'EOF'
+          unqualified-search-registries = []
+          EOF
+          echo "CONTAINERS_REGISTRIES_CONF=$RUNNER_TEMP/registries.conf" >> "$GITHUB_ENV"
+          echo "CONTAINERS_REGISTRIES_CONF_OVERRIDE=" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         env:


### PR DESCRIPTION
## Summary

Fix the post-merge publish failure exposed by Renovate auto-merge #92 after the lockfile update.

The Linux publish jobs now run newer `skopeo`/containers-image, which rejects the GitHub runner's legacy `/etc/containers/registries.conf` v1 file. The workflow now writes a minimal v2 `registries.conf` in `$RUNNER_TEMP` and points containers-image at it before any `skopeo` login/copy/inspect call.

## Verification

- `python3` + PyYAML parsed `.github/workflows/ci.yml`
- `git diff --check`
- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml`
- `nix flake check --no-build -L`
- peer-reviewed by two read-only subagents

## Notes

This is a forward fix for the failed post-merge `main` run from Renovate PR #92. PR checks will skip the publish path as designed; the real proof is the next trusted `main` push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the container publishing workflow to use a consistent registry configuration during image and manifest operations.
  * This helps make release and publish jobs more reliable in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->