### PR TITLE
chore: guard const-oid Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,13 @@
     {
       "matchUpdateTypes": ["major"],
       "automerge": false
+    },
+    {
+      "description": "Keep const-oid on 0.9 until the x509-cert/spki/sigstore stack uses const-oid 0.10-compatible ObjectIdentifier types.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["const-oid"],
+      "allowedVersions": "<0.10.0",
+      "automerge": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- add a Renovate package rule keeping `const-oid` below 0.10 for now
- document the temporary reason: `x509-cert`/`spki`/`sigstore` still expose `const-oid` 0.9 `ObjectIdentifier` types
- prevents repeat failing Renovate PRs like #14 until the dependency stack migrates together

## Verification
- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- added-line secret scan: no obvious hardcoded secrets
- independent peer review: PASS

Assisted-by: vasyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update rules to keep `const-oid` on the 0.9 line for now.
  * Prevented automatic upgrades for that package to avoid pulling in incompatible versions during minor, patch, pin, and digest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->