### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through GitHub's private vulnerability reporting for this repository:
+
+<https://github.com/0x77dev/pdf-sign/security/advisories/new>
+
+Do not open a public issue for a suspected vulnerability. Include enough detail to reproduce the issue when possible: affected version or commit, platform, input files or commands, expected behavior, and observed behavior.
+
+## Supported versions
+
+Security reports are handled for the current `main` branch and the latest published tag or release of `pdf-sign`, if any. If you are unsure whether your build is affected, include the package version, commit, tag, or other build source you used.
+
+## Disclosure
+
+Security fixes are coordinated through the private advisory until a fix is available. Public disclosure should wait until maintainers have had a reasonable chance to investigate and prepare a fix.


### PR DESCRIPTION
## Summary
- add SECURITY.md with the private vulnerability reporting path
- document supported security-report scope and disclosure expectations

## Verification
- added-line secret scan: no matches
- nix flake check --no-build -L: passed
- independent peer review: 2 PASS after fixing the `pdf-sign --version` wording

Full `nix flake check -L` was attempted but timed out after 600s while cold-building dependencies, before any project failure.

Assisted-by: vasyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy with clear instructions for privately reporting vulnerabilities.
  * Included guidance on what details to submit, such as reproduction steps and expected vs. actual behavior.
  * Clarified which releases are covered and how disclosure is coordinated until a fix is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->