### PR TITLE
Add deterministic Homebrew release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -204,7 +204,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
 
       - name: Cachix
         if: ${{ github.event_name != 'push' }}
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
 
       - name: Cachix (trusted push)
         if: ${{ github.event_name == 'push' }}
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
             accept-flake-config = true
 
       - name: Cachix
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -213,7 +213,7 @@ jobs:
             accept-flake-config = true
 
       - name: Cachix
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true
@@ -68,7 +68,7 @@ jobs:
           cp -L result/bin/pdf-sign "dist/pdf-sign-${{ runner.os }}-$(uname -m)"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pdf-sign-${{ matrix.name }}
           path: dist/*
@@ -91,13 +91,13 @@ jobs:
           - name: macos-arm64
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pdf-sign-${{ matrix.name }}
           path: dist
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: dist/*
 
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true
@@ -183,7 +183,7 @@ jobs:
           echo "digest=$(cat "$RUNNER_TEMP/image-digest")" >> "$GITHUB_OUTPUT"
 
       - name: Attest image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.push-image.outputs.digest }}
@@ -207,7 +207,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true
@@ -286,7 +286,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest manifest
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build (flake)
         run: |
           nix build .#pdf-sign --out-link result
+          nix build .#homebrew-bottle --out-link result-homebrew-bottle
 
       - name: Test (flake checks)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,11 @@ jobs:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build (flake)
-        run: |
-          nix build .#pdf-sign --out-link result
-          nix build .#homebrew-bottle --out-link result-homebrew-bottle
-
       - name: Test (flake checks)
-        run: |
-          nix flake check -L
+        run: nix flake check -L
+
+      - name: Build (flake)
+        run: nix build .#pdf-sign .#homebrew-bottle --out-link result
 
       - name: Collect artifact
         run: |

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
           tag="$REQUESTED_TAG"
-          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Invalid release tag: $tag" >&2
             exit 1
           fi
@@ -91,7 +91,7 @@ jobs:
           print(version)
           PY
           )"
-          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Cargo.toml contains an unsupported semantic version: $version" >&2
             exit 1
           fi
@@ -138,7 +138,7 @@ jobs:
             accept-flake-config = true
 
       - name: Publish native build to Cachix
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
             accept-flake-config = true
 
       - name: Use Cachix release inputs
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -471,7 +471,7 @@ jobs:
             accept-flake-config = true
 
       - name: Use Cachix
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: pdf-sign
 

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,756 @@
+name: Homebrew release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing immutable release tag (for example, v0.2.1)
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: homebrew-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  SOURCE_REPOSITORY: signed-page/pdf
+  TAP_REPOSITORY: signed-page/homebrew-tap
+  BOTTLE_IMAGE: ghcr.io/signed-page/tap/pdf
+
+jobs:
+  resolve:
+    name: Resolve immutable tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+    steps:
+      - name: Checkout requested tag
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve and validate tag
+        id: resolve
+        env:
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REPOSITORY" != "$SOURCE_REPOSITORY" ]]; then
+            echo "This release workflow is authoritative only in $SOURCE_REPOSITORY" >&2
+            exit 1
+          fi
+
+          tag="$REQUESTED_TAG"
+          if [[ ! "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
+
+          if ! git show-ref --verify --quiet "refs/tags/$tag"; then
+            echo "Tag does not exist: $tag" >&2
+            exit 1
+          fi
+
+          object_type="$(git cat-file -t "refs/tags/$tag")"
+          if [[ "$object_type" != "tag" && "$object_type" != "commit" ]]; then
+            echo "Tag $tag resolves from unsupported object type $object_type" >&2
+            exit 1
+          fi
+
+          source_sha="$(git rev-parse "refs/tags/$tag^{commit}")"
+          if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Tag did not resolve to a full commit SHA" >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$source_sha" ]]; then
+            echo "Checkout does not match resolved tag commit" >&2
+            exit 1
+          fi
+
+          version="$(python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          document = tomllib.loads(pathlib.Path("Cargo.toml").read_text())
+          version = document.get("workspace", {}).get("package", {}).get("version")
+          if not isinstance(version, str) or not version:
+              raise SystemExit("Cargo.toml has no workspace.package.version")
+          print(version)
+          PY
+          )"
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Cargo.toml contains an unsupported semantic version: $version" >&2
+            exit 1
+          fi
+          if [[ "$tag" != "v$version" ]]; then
+            echo "Tag $tag does not match Cargo.toml version $version" >&2
+            exit 1
+          fi
+
+          {
+            printf 'tag=%s\n' "$tag"
+            printf 'version=%s\n' "$version"
+            printf 'source_sha=%s\n' "$source_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  bottles:
+    name: Bottle (${{ matrix.name }})
+    needs: resolve
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            runs_on: ubuntu-24.04
+          - name: linux-arm64
+            runs_on: ubuntu-24.04-arm
+          - name: macos-arm64
+            runs_on: macos-26
+    steps:
+      - name: Checkout resolved commit
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.resolve.outputs.source_sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Publish native build to Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: pdf-sign
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build native Homebrew bottle
+        run: nix build -L .#homebrew-bottle --out-link result-homebrew-bottle
+
+  release-build:
+    name: Coordinate Homebrew release
+    needs: [resolve, bottles]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout resolved commit
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.resolve.outputs.source_sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Use Cachix release inputs
+        uses: cachix/cachix-action@v17
+        with:
+          name: pdf-sign
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build coordinated release
+        run: nix build -L .#homebrew-release --out-link result
+
+      - name: Validate and stage release outputs
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          release_json="result/metadata/release.json"
+          bottle_json="result/metadata/pdf.bottle.json"
+          source_filename="pdf-sign-${VERSION}-source.tar.gz"
+          source_file="result/source/$source_filename"
+
+          for file in "$release_json" "$bottle_json" "$source_file"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing coordinated release output: $file" >&2
+              exit 1
+            fi
+          done
+
+          jq -e \
+            --arg version "$VERSION" \
+            --arg filename "$source_filename" \
+            --arg repository "$BOTTLE_IMAGE" \
+            '.schema == 1 and
+             .formula == "pdf" and
+             .version == $version and
+             .source.filename == $filename and
+             (.source.sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+             .oci.repository == $repository and
+             (.oci.indexDigest | type == "string" and test("^sha256:[0-9a-f]{64}$"))' \
+            "$release_json" >/dev/null
+          jq -e 'type == "object"' "$bottle_json" >/dev/null
+
+          expected_source_sha="$(jq -er '.source.sha256' "$release_json")"
+          actual_source_sha="$(sha256sum "$source_file" | cut -d ' ' -f 1)"
+          if [[ "$actual_source_sha" != "$expected_source_sha" ]]; then
+            echo "Coordinated source archive digest mismatch" >&2
+            exit 1
+          fi
+
+          mkdir -p source-publication/source source-publication/metadata formula-metadata
+          cp --dereference "$source_file" "source-publication/source/$source_filename"
+          cp --dereference "$release_json" source-publication/metadata/release.json
+          cp --dereference "$release_json" formula-metadata/release.json
+          cp --dereference "$bottle_json" formula-metadata/pdf.bottle.json
+
+      - name: Upload source publication inputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: homebrew-source-${{ needs.resolve.outputs.source_sha }}
+          path: source-publication/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: Upload Formula metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: homebrew-metadata-${{ needs.resolve.outputs.source_sha }}
+          path: formula-metadata/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish-source:
+    name: Publish immutable source
+    needs: [resolve, release-build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download source publication inputs
+        uses: actions/download-artifact@v8
+        with:
+          name: homebrew-source-${{ needs.resolve.outputs.source_sha }}
+          path: release-artifact
+
+      - name: Validate and publish source asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          source_filename="pdf-sign-${VERSION}-source.tar.gz"
+          release_json="release-artifact/metadata/release.json"
+          source_file="release-artifact/source/$source_filename"
+
+          expected_files="$(printf '%s\n' \
+            './metadata/release.json' \
+            "./source/$source_filename")"
+          actual_files="$(cd release-artifact && find . -type f -print | LC_ALL=C sort)"
+          if [[ "$actual_files" != "$expected_files" ]]; then
+            echo "Source publication artifact contains missing or unexpected files" >&2
+            printf 'Expected:\n%s\nActual:\n%s\n' "$expected_files" "$actual_files" >&2
+            exit 1
+          fi
+
+          jq -e \
+            --arg version "$VERSION" \
+            --arg filename "$source_filename" \
+            --arg repository "$BOTTLE_IMAGE" \
+            '.schema == 1 and
+             .formula == "pdf" and
+             .version == $version and
+             .source.filename == $filename and
+             (.source.sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+             .oci.repository == $repository and
+             (.oci.indexDigest | type == "string" and test("^sha256:[0-9a-f]{64}$"))' \
+            "$release_json" >/dev/null
+
+          expected_source_sha="$(jq -er '.source.sha256' "$release_json")"
+          actual_source_sha="$(sha256sum "$source_file" | cut -d ' ' -f 1)"
+          if [[ "$actual_source_sha" != "$expected_source_sha" ]]; then
+            echo "Source publication artifact digest mismatch" >&2
+            exit 1
+          fi
+
+          resolved_remote_sha="$(gh api "repos/$SOURCE_REPOSITORY/commits/$TAG" --jq '.sha')"
+          if [[ "$resolved_remote_sha" != "$SOURCE_SHA" ]]; then
+            echo "Public tag moved after resolution" >&2
+            exit 1
+          fi
+
+          if ! gh release view "$TAG" --repo "$SOURCE_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$SOURCE_REPOSITORY" \
+              --verify-tag \
+              --title "$TAG" \
+              --notes "Vendored corresponding source for pdf-sign $VERSION."
+          fi
+
+          if [[ "$(gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft')" != "false" ]]; then
+            echo "Refusing to publish into a draft release" >&2
+            exit 1
+          fi
+
+          mapfile -t asset_names < <(
+            gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json assets --jq '.assets[].name' |
+              LC_ALL=C sort
+          )
+          case "${#asset_names[@]}" in
+            0)
+              gh release upload "$TAG" "$source_file" --repo "$SOURCE_REPOSITORY"
+              ;;
+            1)
+              if [[ "${asset_names[0]}" != "$source_filename" ]]; then
+                echo "Release already contains an unexpected asset: ${asset_names[0]}" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Release contains unexpected extra assets" >&2
+              printf '%s\n' "${asset_names[@]}" >&2
+              exit 1
+              ;;
+          esac
+
+          mapfile -t published_assets < <(
+            gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json assets --jq '.assets[].name' |
+              LC_ALL=C sort
+          )
+          if [[ "${#published_assets[@]}" -ne 1 || "${published_assets[0]}" != "$source_filename" ]]; then
+            echo "Release asset set is not exactly the expected source archive" >&2
+            exit 1
+          fi
+
+          published_dir="$RUNNER_TEMP/published-source"
+          rm -rf "$published_dir"
+          mkdir -p "$published_dir"
+          gh release download "$TAG" \
+            --repo "$SOURCE_REPOSITORY" \
+            --pattern "$source_filename" \
+            --dir "$published_dir"
+          published_sha="$(sha256sum "$published_dir/$source_filename" | cut -d ' ' -f 1)"
+          if [[ "$published_sha" != "$expected_source_sha" ]]; then
+            echo "Existing release asset differs from the immutable Nix source archive" >&2
+            exit 1
+          fi
+
+      - name: Attest published source asset
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ runner.temp }}/published-source/pdf-sign-${{ needs.resolve.outputs.version }}-source.tar.gz
+
+  dispatch:
+    name: Dispatch tap publication
+    needs: [resolve, publish-source]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Revalidate public tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          resolved_remote_sha="$(gh api "repos/$SOURCE_REPOSITORY/commits/$TAG" --jq '.sha')"
+          if [[ "$resolved_remote_sha" != "$SOURCE_SHA" ]]; then
+            echo "Public tag moved before tap dispatch" >&2
+            exit 1
+          fi
+
+      - name: Mint dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.HOMEBREW_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_PUBLISHER_PRIVATE_KEY }}
+          owner: signed-page
+          repositories: homebrew-tap
+          permission-contents: write
+
+      - name: Dispatch immutable release metadata
+        env:
+          GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg source_repository "$SOURCE_REPOSITORY" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg tag "$TAG" \
+            --arg version "$VERSION" \
+            '{
+              event_type: "pdf-sign-release",
+              client_payload: {
+                source_repository: $source_repository,
+                source_sha: $source_sha,
+                tag: $tag,
+                version: $version
+              }
+            }' |
+            gh api --method POST "repos/$TAP_REPOSITORY/dispatches" --input -
+
+  update-tap:
+    name: Open Formula update
+    needs: [resolve, release-build, dispatch]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Download Formula metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: homebrew-metadata-${{ needs.resolve.outputs.source_sha }}
+          path: release-metadata
+
+      - name: Validate Formula metadata
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          expected_files="$(printf '%s\n' './pdf.bottle.json' './release.json')"
+          actual_files="$(cd release-metadata && find . -type f -print | LC_ALL=C sort)"
+          if [[ "$actual_files" != "$expected_files" ]]; then
+            echo "Formula metadata artifact contains missing or unexpected files" >&2
+            exit 1
+          fi
+          jq -e \
+            --arg version "$VERSION" \
+            --arg repository "$BOTTLE_IMAGE" \
+            '.schema == 1 and
+             .formula == "pdf" and
+             .version == $version and
+             .oci.repository == $repository and
+             (.oci.indexDigest | type == "string" and test("^sha256:[0-9a-f]{64}$"))' \
+            release-metadata/release.json >/dev/null
+          jq -e 'type == "object"' release-metadata/pdf.bottle.json >/dev/null
+
+      - name: Checkout resolved source for pinned OCI tooling
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          path: source
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Use Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: pdf-sign
+
+      - name: Wait for the exact public bottle index
+        shell: nix develop ./source --command bash -euo pipefail {0}
+        run: |
+          expected_digest="$(jq -er '.oci.indexDigest' release-metadata/release.json)"
+          auth_file="$RUNNER_TEMP/anonymous-registry-auth.json"
+          manifest_file="$RUNNER_TEMP/pdf-bottle-index.json"
+          error_file="$RUNNER_TEMP/pdf-bottle-inspect.err"
+          printf '{"auths":{}}\n' > "$auth_file"
+
+          max_attempts=160
+          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+            if skopeo inspect --authfile "$auth_file" --raw "docker://$BOTTLE_IMAGE:${{ needs.resolve.outputs.version }}" \
+              > "$manifest_file" 2> "$error_file"; then
+              media_type="$(jq -er '.mediaType' "$manifest_file")"
+              if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
+                echo "Published tag is not an OCI image index: $media_type" >&2
+                exit 1
+              fi
+              actual_digest="sha256:$(sha256sum "$manifest_file" | cut -d ' ' -f 1)"
+              if [[ "$actual_digest" == "$expected_digest" ]]; then
+                echo "Observed immutable public bottle index $actual_digest"
+                break
+              fi
+              echo "Published version tag has unexpected digest $actual_digest (expected $expected_digest)" >&2
+              exit 1
+            fi
+
+            if ((attempt == max_attempts)); then
+              echo "Bottle index did not become anonymously readable" >&2
+              cat "$error_file" >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # 2026.07.13.1
+        with:
+          stable: true
+
+      - name: Mint tap update token
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.HOMEBREW_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_PUBLISHER_PRIVATE_KEY }}
+          owner: signed-page
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout tap with App token
+        uses: actions/checkout@v7
+        with:
+          repository: signed-page/homebrew-tap
+          ref: main
+          fetch-depth: 0
+          path: tap
+          token: ${{ steps.tap-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Resolve App bot identity
+        id: app-identity
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          bot_login="${APP_SLUG}[bot]"
+          bot_id="$(gh api "/users/$bot_login" --jq '.id')"
+          if [[ ! "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "Could not resolve GitHub App bot identity" >&2
+            exit 1
+          fi
+          printf 'name=%s\n' "$bot_login" >> "$GITHUB_OUTPUT"
+          printf 'email=%s+%s@users.noreply.github.com\n' "$bot_id" "$bot_login" >> "$GITHUB_OUTPUT"
+
+      - name: Apply metadata and create or reuse release branch
+        id: prepare-pr
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.tap-token.outputs.token }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          VERSION: ${{ needs.resolve.outputs.version }}
+          BOT_NAME: ${{ steps.app-identity.outputs.name }}
+          BOT_EMAIL: ${{ steps.app-identity.outputs.email }}
+        run: |
+          set -euo pipefail
+
+          tap_checkout="$GITHUB_WORKSPACE/tap"
+          tap_path="$(brew --repository)/Library/Taps/signed-page/homebrew-tap"
+          mkdir -p "$(dirname "$tap_path")"
+          if [[ -e "$tap_path" || -L "$tap_path" ]]; then
+            if [[ "$(realpath "$tap_path")" != "$(realpath "$tap_checkout")" ]]; then
+              echo "Homebrew tap path is already occupied by another checkout" >&2
+              exit 1
+            fi
+          else
+            ln -s "$tap_checkout" "$tap_path"
+          fi
+          brew trust signed-page/tap
+
+          cd "$tap_checkout"
+          git config user.name "$BOT_NAME"
+          git config user.email "$BOT_EMAIL"
+          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+            echo "Tap checkout is not the fetched main branch" >&2
+            exit 1
+          fi
+          if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+            echo "Tap checkout was dirty before metadata application" >&2
+            exit 1
+          fi
+
+          ruby scripts/update-pdf.rb \
+            "$GITHUB_WORKSPACE/release-metadata/release.json" \
+            "$GITHUB_WORKSPACE/release-metadata/pdf.bottle.json"
+
+          mapfile -t status_lines < <(git status --porcelain=v1 --untracked-files=all)
+          if [[ "${#status_lines[@]}" -eq 0 ]]; then
+            echo "Tap main already contains pdf $VERSION with identical metadata"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${#status_lines[@]}" -ne 1 || "${status_lines[0]:3}" != "Formula/pdf.rb" ]]; then
+            echo "Updater changed files other than Formula/pdf.rb" >&2
+            printf '%s\n' "${status_lines[@]}" >&2
+            exit 1
+          fi
+          if [[ "${status_lines[0]:0:2}" != " M" && "${status_lines[0]:0:2}" != "??" ]]; then
+            echo "Updater left an unsupported Formula git state: ${status_lines[0]}" >&2
+            exit 1
+          fi
+          if [[ ! -f Formula/pdf.rb ]]; then
+            echo "Updater did not produce Formula/pdf.rb" >&2
+            exit 1
+          fi
+
+          branch="release/pdf-v$VERSION"
+          expected_blob="$(git hash-object Formula/pdf.rb)"
+          remote_listing="$RUNNER_TEMP/release-branch"
+          set +e
+          git ls-remote --exit-code --heads origin "refs/heads/$branch" > "$remote_listing"
+          branch_status=$?
+          set -e
+
+          case "$branch_status" in
+            0)
+              read -r remote_sha _ < "$remote_listing"
+              if [[ ! "$remote_sha" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "Remote release branch has an invalid commit ID" >&2
+                exit 1
+              fi
+              git fetch --no-tags origin "refs/heads/$branch:refs/remotes/origin/$branch"
+              if [[ "$(git rev-parse "origin/$branch")" != "$remote_sha" ]]; then
+                echo "Remote release branch changed during validation" >&2
+                exit 1
+              fi
+              merge_base="$(git merge-base origin/main "origin/$branch" || true)"
+              if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "Remote release branch has no valid main-branch ancestry" >&2
+                exit 1
+              fi
+              mapfile -t remote_paths < <(git diff --name-only "$merge_base" "origin/$branch")
+              if [[ "${#remote_paths[@]}" -ne 1 || "${remote_paths[0]}" != "Formula/pdf.rb" ]]; then
+                echo "Existing release branch contains divergent changes" >&2
+                exit 1
+              fi
+              remote_blob="$(git rev-parse "origin/$branch:Formula/pdf.rb")"
+              if [[ "$remote_blob" != "$expected_blob" ]]; then
+                echo "Existing release branch contains divergent Formula metadata" >&2
+                exit 1
+              fi
+              ;;
+            2)
+              git switch -c "$branch" origin/main
+              git add -- Formula/pdf.rb
+              mapfile -t staged_paths < <(git diff --cached --name-only)
+              if [[ "${#staged_paths[@]}" -ne 1 || "${staged_paths[0]}" != "Formula/pdf.rb" ]]; then
+                echo "Refusing to commit anything except Formula/pdf.rb" >&2
+                exit 1
+              fi
+              if [[ -n "$(git diff --name-only)" || -n "$(git ls-files --others --exclude-standard)" ]]; then
+                echo "Tap checkout has uncommitted files outside the Formula update" >&2
+                exit 1
+              fi
+              git commit -m "pdf $VERSION"
+              git push --set-upstream origin "$branch"
+              ;;
+            *)
+              echo "Failed to determine whether release branch exists" >&2
+              exit "$branch_status"
+              ;;
+          esac
+
+          printf 'branch=%s\n' "$branch" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse PR and request auto-merge
+        if: steps.prepare-pr.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          BRANCH: ${{ steps.prepare-pr.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          remote_sha="$(git -C tap ls-remote --heads origin "refs/heads/$BRANCH" | cut -f 1)"
+          if [[ ! "$remote_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Release branch is not available on the tap" >&2
+            exit 1
+          fi
+
+          open_prs="$(gh pr list \
+            --repo "$TAP_REPOSITORY" \
+            --state open \
+            --base main \
+            --head "$BRANCH" \
+            --limit 100 \
+            --json number,title,headRefOid,baseRefName,url)"
+          open_count="$(jq 'length' <<< "$open_prs")"
+          case "$open_count" in
+            0)
+              historical_count="$(gh pr list \
+                --repo "$TAP_REPOSITORY" \
+                --state closed \
+                --base main \
+                --head "$BRANCH" \
+                --limit 100 \
+                --json number | jq 'length')"
+              if [[ "$historical_count" != "0" ]]; then
+                echo "A closed or merged PR already used $BRANCH while main still differs" >&2
+                exit 1
+              fi
+              pr_url="$(gh pr create \
+                --repo "$TAP_REPOSITORY" \
+                --base main \
+                --head "$BRANCH" \
+                --title "pdf $VERSION" \
+                --body "Updates the pdf Formula from immutable signed-page/pdf commit \`$SOURCE_SHA\`.")"
+              pr_number="${pr_url##*/}"
+              ;;
+            1)
+              pr_number="$(jq -er '.[0].number' <<< "$open_prs")"
+              title="$(jq -er '.[0].title' <<< "$open_prs")"
+              head_sha="$(jq -er '.[0].headRefOid' <<< "$open_prs")"
+              base_ref="$(jq -er '.[0].baseRefName' <<< "$open_prs")"
+              if [[ "$title" != "pdf $VERSION" || "$head_sha" != "$remote_sha" || "$base_ref" != "main" ]]; then
+                echo "Existing Formula PR is divergent" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Multiple open Formula PRs exist for $BRANCH" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Could not resolve Formula PR number" >&2
+            exit 1
+          fi
+          auto_merge_method="$(gh pr view "$pr_number" \
+            --repo "$TAP_REPOSITORY" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest.mergeMethod // ""')"
+          case "$auto_merge_method" in
+            "")
+              gh pr merge "$pr_number" --repo "$TAP_REPOSITORY" --auto --squash
+              ;;
+            SQUASH)
+              echo "Squash auto-merge is already requested for PR #$pr_number"
+              ;;
+            *)
+              echo "PR #$pr_number has a non-squash auto-merge request" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -35,7 +35,7 @@ jobs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}
     steps:
       - name: Checkout requested tag
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -125,7 +125,7 @@ jobs:
             runs_on: macos-26
     steps:
       - name: Checkout resolved commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -155,7 +155,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout resolved commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -457,7 +457,7 @@ jobs:
           jq -e 'type == "object"' release-metadata/pdf.bottle.json >/dev/null
 
       - name: Checkout resolved source for pinned OCI tooling
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -534,7 +534,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout tap with App token
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: signed-page/homebrew-tap
           ref: main

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -424,7 +424,7 @@ jobs:
     name: Open Formula update
     needs: [resolve, release-build, dispatch]
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -475,35 +475,42 @@ jobs:
         with:
           name: pdf-sign
 
-      - name: Wait for the exact public bottle index
+      - name: Wait for verified public bottle index
         shell: nix develop ./source --command bash -euo pipefail {0}
         run: |
           expected_digest="$(jq -er '.oci.indexDigest' release-metadata/release.json)"
+          version="${{ needs.resolve.outputs.version }}"
+          verified_tag="$version-verified"
           auth_file="$RUNNER_TEMP/anonymous-registry-auth.json"
           manifest_file="$RUNNER_TEMP/pdf-bottle-index.json"
+          version_manifest_file="$RUNNER_TEMP/pdf-bottle-version-index.json"
           error_file="$RUNNER_TEMP/pdf-bottle-inspect.err"
           printf '{"auths":{}}\n' > "$auth_file"
 
-          max_attempts=160
+          max_attempts=320
           for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-            if skopeo inspect --authfile "$auth_file" --raw "docker://$BOTTLE_IMAGE:${{ needs.resolve.outputs.version }}" \
+            if skopeo inspect --authfile "$auth_file" --raw "docker://$BOTTLE_IMAGE:$verified_tag" \
               > "$manifest_file" 2> "$error_file"; then
-              media_type="$(jq -er '.mediaType' "$manifest_file")"
-              if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
-                echo "Published tag is not an OCI image index: $media_type" >&2
+              actual_digest="sha256:$(sha256sum "$manifest_file" | cut -d ' ' -f 1)"
+              if [[ "$actual_digest" != "$expected_digest" ]]; then
+                echo "Verified completion tag has unexpected digest $actual_digest (expected $expected_digest)" >&2
                 exit 1
               fi
-              actual_digest="sha256:$(sha256sum "$manifest_file" | cut -d ' ' -f 1)"
-              if [[ "$actual_digest" == "$expected_digest" ]]; then
-                echo "Observed immutable public bottle index $actual_digest"
-                break
+
+              skopeo inspect --authfile "$auth_file" --raw "docker://$BOTTLE_IMAGE:$version" \
+                > "$version_manifest_file"
+              version_digest="sha256:$(sha256sum "$version_manifest_file" | cut -d ' ' -f 1)"
+              if [[ "$version_digest" != "$expected_digest" ]]; then
+                echo "Published version tag has unexpected digest $version_digest (expected $expected_digest)" >&2
+                exit 1
               fi
-              echo "Published version tag has unexpected digest $actual_digest (expected $expected_digest)" >&2
-              exit 1
+
+              echo "Observed verified public bottle index $actual_digest"
+              break
             fi
 
             if ((attempt == max_attempts)); then
-              echo "Bottle index did not become anonymously readable" >&2
+              echo "Verified bottle index did not become anonymously readable" >&2
               cat "$error_file" >&2
               exit 1
             fi

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.source_sha }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true
@@ -162,7 +162,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.source_sha }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true
@@ -222,7 +222,7 @@ jobs:
           cp --dereference "$bottle_json" formula-metadata/pdf.bottle.json
 
       - name: Upload source publication inputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: homebrew-source-${{ needs.resolve.outputs.source_sha }}
           path: source-publication/
@@ -231,7 +231,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Formula metadata
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: homebrew-metadata-${{ needs.resolve.outputs.source_sha }}
           path: formula-metadata/
@@ -250,7 +250,7 @@ jobs:
       attestations: write
     steps:
       - name: Download source publication inputs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: homebrew-source-${{ needs.resolve.outputs.source_sha }}
           path: release-artifact
@@ -361,7 +361,7 @@ jobs:
           fi
 
       - name: Attest published source asset
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: ${{ runner.temp }}/published-source/pdf-sign-${{ needs.resolve.outputs.version }}-source.tar.gz
 
@@ -429,7 +429,7 @@ jobs:
       contents: read
     steps:
       - name: Download Formula metadata
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: homebrew-metadata-${{ needs.resolve.outputs.source_sha }}
           path: release-metadata
@@ -465,7 +465,7 @@ jobs:
           path: source
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           extra_nix_config: |
             accept-flake-config = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-gpg"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-sigstore"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "GPL-3.0-only"
 authors = ["Mykhailo Marynenko <mykhailo@0x77.dev>"]
-repository = "https://github.com/0x77dev/pdf-sign"
+repository = "https://github.com/signed-page/pdf"
 
 [workspace.dependencies]
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pdf-sign
 
-[![built with garnix](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2F0x77dev%2Fpdf-sign%3Fbranch%3Dmain)](https://garnix.io/repo/0x77dev/pdf-sign) [![CI](https://github.com/0x77dev/pdf-sign/actions/workflows/ci.yml/badge.svg)](https://github.com/0x77dev/pdf-sign/actions/workflows/ci.yml)
+[![CI](https://github.com/signed-page/pdf/actions/workflows/ci.yml/badge.svg)](https://github.com/signed-page/pdf/actions/workflows/ci.yml)
 
 PDF signing utility written in Rust that supports both **OpenPGP (GPG)** and **Sigstore (keyless OIDC)** signatures, appending cryptographic signatures directly to PDFs, making it easy to sign and verify documents without heavyweight PDF signing stacks, making your PDFs authentic, tamper-proof, while being fully compatible with regular readers.
 
@@ -23,17 +23,24 @@ Many "enterprise PDF signing" solutions require a full **CMS/PKCS#7** / **X.509 
 
 ## Quickstart
 
+### Install with Homebrew
+
+```bash
+brew install signed-page/tap/pdf
+pdf-sign --help
+```
+
 ### Install with Nix
 
 ```bash
-nix profile install github:0x77dev/pdf-sign#pdf-sign
+nix profile install github:signed-page/pdf#pdf-sign
 pdf-sign --help
 ```
 
 ### Install with Cargo
 
 ```bash
-cargo install --git https://github.com/0x77dev/pdf-sign --locked
+cargo install --git https://github.com/signed-page/pdf --locked
 
 # GPG signing (default backend)
 pdf-sign sign document.pdf --key 0xDEADBEEF
@@ -49,8 +56,8 @@ pdf-sign verify document_signed.pdf
 
 ```bash
 # Clone and build
-git clone https://github.com/0x77dev/pdf-sign
-cd pdf-sign
+git clone https://github.com/signed-page/pdf
+cd pdf
 cargo build --release
 ./target/release/pdf-sign --help
 
@@ -64,10 +71,10 @@ nix build
 Multi-platform images (`linux/amd64`, `linux/arm64`, `darwin/arm64`) are published to GHCR with [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations).
 
 ```bash
-docker pull ghcr.io/0x77dev/pdf-sign
+docker pull ghcr.io/signed-page/pdf
 
 # Verify attestation
-gh attestation verify oci://ghcr.io/0x77dev/pdf-sign:latest --repo 0x77dev/pdf-sign
+gh attestation verify oci://ghcr.io/signed-page/pdf:latest --repo signed-page/pdf
 ```
 
 **GPG signing** — mount your host GPG agent socket and keyring (Linux only — [macOS Docker Desktop cannot forward Unix sockets](https://github.com/docker/for-mac/issues/483)):
@@ -77,7 +84,7 @@ docker run --rm \
   -v "$(gpgconf --list-dirs agent-socket)":/gnupg/S.gpg-agent \
   -v ~/.gnupg/pubring.kbx:/gnupg/pubring.kbx:ro \
   -v "$PWD":/data \
-  ghcr.io/0x77dev/pdf-sign sign --key 0xDEADBEEF document.pdf
+  ghcr.io/signed-page/pdf sign --key 0xDEADBEEF document.pdf
 ```
 
 **Sigstore signing (interactive)** — forward the OIDC callback port:
@@ -86,7 +93,7 @@ docker run --rm \
 docker run --rm \
   -p 127.0.0.1:8080:8080 -e OIDC_REDIRECT_PORT=8080 \
   -v "$PWD":/data \
-  ghcr.io/0x77dev/pdf-sign sign --backend sigstore document.pdf
+  ghcr.io/signed-page/pdf sign --backend sigstore document.pdf
 ```
 
 **Sigstore signing (CI/non-interactive)** — pass a pre-obtained identity token:
@@ -95,14 +102,14 @@ docker run --rm \
 docker run --rm \
   -e SIGSTORE_IDENTITY_TOKEN="$OIDC_TOKEN" \
   -v "$PWD":/data \
-  ghcr.io/0x77dev/pdf-sign sign --backend sigstore document.pdf
+  ghcr.io/signed-page/pdf sign --backend sigstore document.pdf
 ```
 
 **Verify signatures:**
 
 ```bash
 docker run --rm -v "$PWD":/data \
-  ghcr.io/0x77dev/pdf-sign verify document_signed.pdf \
+  ghcr.io/signed-page/pdf verify document_signed.pdf \
   --certificate-identity user@example.com \
   --certificate-oidc-issuer https://accounts.google.com
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please report suspected vulnerabilities privately through GitHub's private vulnerability reporting for this repository:
 
-<https://github.com/0x77dev/pdf-sign/security/advisories/new>
+<https://github.com/signed-page/pdf/security/advisories/new>
 
 Do not open a public issue for a suspected vulnerability. Include enough detail to reproduce the issue when possible: affected version or commit, platform, input files or commands, expected behavior, and observed behavior.
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,58 +33,97 @@
       rust-overlay,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlays.default ];
-        };
+    let
+      homebrewSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
 
-        craneLib = crane.mkLib pkgs;
-
-        package = import ./nix/package.nix {
-          inherit pkgs craneLib;
-          lib = pkgs.lib;
-        };
-      in
-      {
-        checks = import ./nix/checks.nix {
-          inherit
-            pkgs
-            craneLib
-            package
-            git-hooks
-            system
-            ;
-        };
-
-        packages =
-          let
-            autocast = import ./nix/demo.nix {
-              inherit pkgs craneLib;
-              lib = pkgs.lib;
-            };
-          in
-          {
-            default = package.pdfSign;
-            pdf-sign = package.pdfSign;
-            image = package.image;
-            inherit autocast;
+      mkPackageFor =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
           };
+          craneLib = crane.mkLib pkgs;
+        in
+        {
+          inherit pkgs craneLib;
+          package = import ./nix/package.nix {
+            inherit pkgs craneLib;
+            lib = pkgs.lib;
+          };
+        };
 
-        devShells.default = import ./nix/shell.nix {
-          inherit pkgs;
-          pdfSign = package.pdfSign;
+      perSystemOutputs = flake-utils.lib.eachDefaultSystem (
+        system:
+        let
+          build = mkPackageFor system;
+          inherit (build) pkgs craneLib package;
           autocast = import ./nix/demo.nix {
             inherit pkgs craneLib;
             lib = pkgs.lib;
           };
-          pre-commit-check = import ./nix/git-hooks.nix {
-            inherit git-hooks system pkgs;
-            src = ./.;
+        in
+        {
+          checks = import ./nix/checks.nix {
+            inherit
+              pkgs
+              craneLib
+              package
+              git-hooks
+              system
+              ;
           };
+
+          packages = {
+            default = package.pdfSign;
+            pdf-sign = package.pdfSign;
+            image = package.image;
+            inherit autocast;
+          }
+          // pkgs.lib.optionalAttrs (builtins.elem system homebrewSystems) {
+            homebrew-bottle = package.homebrewBottle;
+          }
+          // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+            homebrew-source = package.homebrewSource;
+          };
+
+          devShells.default = import ./nix/shell.nix {
+            inherit pkgs;
+            pdfSign = package.pdfSign;
+            inherit autocast;
+            pre-commit-check = import ./nix/git-hooks.nix {
+              inherit git-hooks system pkgs;
+              src = ./.;
+            };
+          };
+        }
+      );
+
+      darwinRelease = mkPackageFor "aarch64-darwin";
+      armLinuxRelease = mkPackageFor "aarch64-linux";
+      x86LinuxRelease = mkPackageFor "x86_64-linux";
+
+      homebrewRelease = x86LinuxRelease.package.mkHomebrewRelease {
+        sourceBundles = {
+          "aarch64-darwin" = darwinRelease.package.homebrewSource;
+          "aarch64-linux" = armLinuxRelease.package.homebrewSource;
+          "x86_64-linux" = x86LinuxRelease.package.homebrewSource;
         };
-      }
-    );
+        bottles = {
+          arm64_sonoma = darwinRelease.package.homebrewBottle;
+          arm64_linux = armLinuxRelease.package.homebrewBottle;
+          x86_64_linux = x86LinuxRelease.package.homebrewBottle;
+        };
+        version = x86LinuxRelease.package.version;
+        sourceRevision =
+          if self ? rev then self.rev else throw "homebrew-release requires a clean Git revision";
+      };
+    in
+    nixpkgs.lib.recursiveUpdate perSystemOutputs {
+      packages."x86_64-linux".homebrew-release = homebrewRelease;
+    };
 }

--- a/nix/homebrew.nix
+++ b/nix/homebrew.nix
@@ -1,0 +1,737 @@
+{
+  pkgs,
+  lib,
+}:
+let
+  formulaName = "pdf";
+  executableName = "pdf-sign";
+  sourceRepository = "signed-page/pdf";
+  ociRepository = "ghcr.io/signed-page/tap/pdf";
+  bottleRootUrl = "https://ghcr.io/v2/signed-page/tap";
+  formulaPath = "Library/Taps/signed-page/homebrew-tap/Formula/pdf.rb";
+  description = "Lightweight PDF signing tool with OpenPGP (GPG) and Sigstore (keyless OIDC) backends";
+
+  bottlePlatforms = {
+    arm64_sonoma = {
+      architecture = "arm64";
+      os = "darwin";
+      "os.version" = "macOS 14";
+    };
+    arm64_linux = {
+      architecture = "arm64";
+      os = "linux";
+    };
+    x86_64_linux = {
+      architecture = "amd64";
+      os = "linux";
+    };
+  };
+
+  requiredBottleTags = [
+    "arm64_sonoma"
+    "arm64_linux"
+    "x86_64_linux"
+  ];
+
+  requiredSourceSystems = [
+    "aarch64-darwin"
+    "aarch64-linux"
+    "x86_64-linux"
+  ];
+
+  sortedNames = attrs: builtins.sort builtins.lessThan (builtins.attrNames attrs);
+  sortedStrings = values: builtins.sort builtins.lessThan values;
+
+  requireVersion =
+    version:
+    if builtins.match "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" version == null then
+      throw "Homebrew release version must be a stable semantic version, got ${builtins.toJSON version}"
+    else
+      version;
+
+  requireRevision =
+    revision:
+    if builtins.match "^[0-9a-f]{40}$" revision == null then
+      throw "Homebrew release sourceRevision must be a lowercase 40-hex commit"
+    else
+      revision;
+
+  requireExactAttrs =
+    label: expected: attrs:
+    if sortedNames attrs == sortedStrings expected then
+      attrs
+    else
+      throw "${label} must contain exactly ${builtins.toJSON expected}, got ${builtins.toJSON (builtins.attrNames attrs)}";
+in
+rec {
+  mkSourceBundle =
+    {
+      src,
+      cargoVendorDir,
+      version,
+    }:
+    let
+      checkedVersion = requireVersion version;
+      sourceRoot = "${executableName}-${checkedVersion}";
+      sourceFilename = "${sourceRoot}-source.tar.gz";
+    in
+    pkgs.runCommand "${sourceRoot}-homebrew-source"
+      {
+        inherit
+          src
+          cargoVendorDir
+          sourceRoot
+          sourceFilename
+          ;
+        nativeBuildInputs = with pkgs; [
+          coreutils
+          findutils
+          gnugrep
+          gnused
+          gnutar
+          gzip
+          jq
+        ];
+        SOURCE_DATE_EPOCH = "1";
+      }
+      ''
+        set -euo pipefail
+        export LC_ALL=C
+
+        test -d "$src"
+        test -f "$src/.cargo/config.toml"
+        test -f "$cargoVendorDir/config.toml"
+
+        work="$TMPDIR/source"
+        root="$work/$sourceRoot"
+        mkdir -p "$root"
+        cp -R --preserve=mode,timestamps,links --no-preserve=ownership "$src"/. "$root"/
+        chmod -R u+rwX "$root"
+
+        if test -e "$root/vendor"; then
+          echo "source tree already contains vendor/" >&2
+          exit 1
+        fi
+        mkdir "$root/vendor"
+
+        dependency_count=0
+        for dependency in "$cargoVendorDir"/*; do
+          name=$(basename "$dependency")
+          if test "$name" = config.toml; then
+            continue
+          fi
+          cp -RL --no-preserve=ownership "$dependency" "$root/vendor/$name"
+          dependency_count=$((dependency_count + 1))
+        done
+        if test "$dependency_count" -eq 0; then
+          echo "Crane vendorCargoDeps produced no vendored dependencies" >&2
+          exit 1
+        fi
+        if find "$root/vendor" -type l -print -quit | grep -q .; then
+          echo "vendored source contains an unresolved symlink" >&2
+          exit 1
+        fi
+
+        printf '\n' >> "$root/.cargo/config.toml"
+        sed "s|$cargoVendorDir|vendor|g" "$cargoVendorDir/config.toml" >> "$root/.cargo/config.toml"
+        if grep -a -q '/nix/store' "$root/.cargo/config.toml"; then
+          echo "archived Cargo configuration contains a Nix store path" >&2
+          exit 1
+        fi
+
+        find "$root" -type d -exec chmod 0755 {} +
+        find "$root" -type f -exec chmod u+rw,go+r,go-w {} +
+
+        mkdir -p "$out"
+        tar \
+          --sort=name \
+          --format=gnu \
+          --mtime="@$SOURCE_DATE_EPOCH" \
+          --owner=0 \
+          --group=0 \
+          --numeric-owner \
+          --hard-dereference \
+          -C "$work" \
+          -cf - \
+          "$sourceRoot" \
+          | gzip --no-name --best > "$out/$sourceFilename"
+
+        source_sha=$(sha256sum "$out/$sourceFilename" | cut -d ' ' -f 1)
+        jq -cnS \
+          --arg filename "$sourceFilename" \
+          --arg sha256 "$source_sha" \
+          '{filename:$filename,sha256:$sha256}' \
+          | tr -d '\n' > "$out/source.json"
+      '';
+
+  mkBottle =
+    {
+      pdfSign,
+      sourceBundle,
+      version,
+      bottleTag,
+      ociPlatform,
+    }:
+    let
+      checkedVersion = requireVersion version;
+      expectedPlatform =
+        bottlePlatforms.${bottleTag}
+          or (throw "unsupported Homebrew bottle tag ${builtins.toJSON bottleTag}");
+      checkedPlatform =
+        if ociPlatform == expectedPlatform then
+          ociPlatform
+        else
+          throw "OCI platform for ${bottleTag} must be ${builtins.toJSON expectedPlatform}";
+      sourceFilename = "${executableName}-${checkedVersion}-source.tar.gz";
+      kegRootName = "${formulaName}/${checkedVersion}";
+      tarFilename = "${formulaName}--${checkedVersion}.${bottleTag}.bottle.tar";
+      compressedFilename = "${tarFilename}.gz";
+      tabArch = if checkedPlatform.architecture == "amd64" then "x86_64" else "arm64";
+      platformJson = builtins.toJSON checkedPlatform;
+
+      kegRoot =
+        pkgs.runCommand "${formulaName}-${checkedVersion}-${bottleTag}-keg"
+          {
+            inherit
+              pdfSign
+              sourceBundle
+              sourceFilename
+              kegRootName
+              ;
+            nativeBuildInputs = with pkgs; [
+              coreutils
+              findutils
+              gnugrep
+              gnutar
+              jq
+            ];
+          }
+          ''
+                      set -euo pipefail
+                      export LC_ALL=C
+
+                      if ! jq -e --arg filename "$sourceFilename" '
+                        type == "object"
+                        and keys == ["filename", "sha256"]
+                        and .filename == $filename
+                        and (.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+                      ' "$sourceBundle/source.json" >/dev/null; then
+                        echo "invalid source bundle metadata" >&2
+                        exit 1
+                      fi
+
+                      source_sha=$(jq -er '.sha256' "$sourceBundle/source.json")
+                      test -f "$sourceBundle/$sourceFilename"
+                      actual_source_sha=$(sha256sum "$sourceBundle/$sourceFilename" | cut -d ' ' -f 1)
+                      if test "$actual_source_sha" != "$source_sha"; then
+                        echo "source archive digest does not match source.json" >&2
+                        exit 1
+                      fi
+
+                      test -x "$pdfSign/bin/${executableName}"
+                      keg="$out/$kegRootName"
+                      mkdir -p "$keg/bin" "$keg/.brew" "$keg/share/licenses/${executableName}"
+                      install -m755 "$pdfSign/bin/${executableName}" "$keg/bin/${executableName}"
+
+                      for directory in lib libexec; do
+                        if test -d "$pdfSign/$directory"; then
+                          mkdir -p "$keg/$directory"
+                          cp -RL --no-preserve=ownership "$pdfSign/$directory"/. "$keg/$directory"/
+                        fi
+                      done
+
+                      tar -xOzf "$sourceBundle/$sourceFilename" "${executableName}-${checkedVersion}/LICENSE" \
+                        > "$keg/share/licenses/${executableName}/LICENSE"
+                      test -s "$keg/share/licenses/${executableName}/LICENSE"
+
+                      source_url="https://github.com/${sourceRepository}/releases/download/v${checkedVersion}/$sourceFilename"
+                      cat > "$keg/.brew/${formulaName}.rb" <<EOF
+            class Pdf < Formula
+              desc "${description}"
+              homepage "https://signed.page"
+              url "$source_url"
+              sha256 "$source_sha"
+              license "GPL-3.0-only"
+
+              def install
+                bin.install "${executableName}"
+              end
+            end
+            EOF
+
+                      find "$keg" -type d -exec chmod 0755 {} +
+                      find "$keg" -type f -exec chmod 0644 {} +
+                      chmod 0755 "$keg/bin/${executableName}"
+
+                      if grep -R -a -n -E \
+                        '/nix/store|/opt/homebrew(/Cellar)?|/home/linuxbrew/\.linuxbrew(/Cellar)?|/usr/local/(Cellar|Homebrew)' \
+                        "$keg"; then
+                        echo "Keg contains a build-time Nix or Homebrew prefix" >&2
+                        exit 1
+                      fi
+          '';
+
+      layerImage = pkgs.dockerTools.buildImage {
+        name = "homebrew-${formulaName}-${bottleTag}";
+        tag = checkedVersion;
+        copyToRoot = kegRoot;
+        compressor = "none";
+        created = "1970-01-01T00:00:01Z";
+      };
+      layer = layerImage.layer;
+    in
+    pkgs.runCommand "${formulaName}-${checkedVersion}-${bottleTag}-bottle"
+      {
+        inherit
+          layer
+          sourceBundle
+          sourceFilename
+          kegRootName
+          tarFilename
+          compressedFilename
+          bottleTag
+          tabArch
+          platformJson
+          ;
+        releaseVersion = checkedVersion;
+        nativeBuildInputs = with pkgs; [
+          coreutils
+          findutils
+          gawk
+          gzip
+          jq
+          gnutar
+        ];
+      }
+      ''
+        set -euo pipefail
+        export LC_ALL=C
+
+        test -f "$layer/layer.tar"
+        test -f "$sourceBundle/source.json"
+        mkdir -p "$out" "$TMPDIR/unpacked"
+        cp "$layer/layer.tar" "$out/$tarFilename"
+        gzip --no-name --best --stdout "$out/$tarFilename" > "$out/$compressedFilename"
+        gzip --decompress --stdout "$out/$compressedFilename" | cmp - "$out/$tarFilename"
+
+        tar -xf "$out/$tarFilename" -C "$TMPDIR/unpacked"
+        test -d "$TMPDIR/unpacked/$kegRootName"
+        installed_size=$(
+          find "$TMPDIR/unpacked/$kegRootName" -type f -printf '%s\n' \
+            | awk '{ total += $1 } END { print total + 0 }'
+        )
+
+        uncompressed_sha=$(sha256sum "$out/$tarFilename" | cut -d ' ' -f 1)
+        compressed_sha=$(sha256sum "$out/$compressedFilename" | cut -d ' ' -f 1)
+        uncompressed_size=$(stat --format='%s' "$out/$tarFilename")
+        compressed_size=$(stat --format='%s' "$out/$compressedFilename")
+        source_sha=$(jq -er '.sha256' "$sourceBundle/source.json")
+        source_url="https://github.com/${sourceRepository}/releases/download/v$releaseVersion/$sourceFilename"
+
+        jq -cnS \
+          --arg formula "${formulaName}" \
+          --arg version "$releaseVersion" \
+          --arg tag "$bottleTag" \
+          --arg sourceFilename "$sourceFilename" \
+          --arg sourceSha "$source_sha" \
+          --arg sourceUrl "$source_url" \
+          --argjson ociPlatform "$platformJson" \
+          --arg filename "$compressedFilename" \
+          --arg sha256 "$compressed_sha" \
+          --argjson size "$compressed_size" \
+          --argjson installedSize "$installed_size" \
+          --arg uncompressedFilename "$tarFilename" \
+          --arg uncompressedSha256 "$uncompressed_sha" \
+          --argjson uncompressedSize "$uncompressed_size" \
+          '{
+            schema:1,
+            formula:$formula,
+            version:$version,
+            tag:$tag,
+            source:{filename:$sourceFilename,sha256:$sourceSha,url:$sourceUrl},
+            ociPlatform:$ociPlatform,
+            bottle:{
+              filename:$filename,
+              sha256:$sha256,
+              size:$size,
+              installedSize:$installedSize,
+              uncompressedFilename:$uncompressedFilename,
+              uncompressedSha256:$uncompressedSha256,
+              uncompressedSize:$uncompressedSize,
+              cellar:"any_skip_relocation"
+            }
+          }' \
+          | tr -d '\n' > "$out/bottle.json"
+      '';
+
+  mkRelease =
+    {
+      sourceBundles,
+      bottles,
+      version,
+      sourceRevision,
+    }:
+    let
+      checkedVersion = requireVersion version;
+      checkedRevision = requireRevision sourceRevision;
+      checkedSources = requireExactAttrs "sourceBundles" requiredSourceSystems sourceBundles;
+      checkedBottles = requireExactAttrs "bottles" requiredBottleTags bottles;
+    in
+    pkgs.runCommand "${formulaName}-${checkedVersion}-homebrew-release"
+      {
+        sourceAarch64Darwin = checkedSources."aarch64-darwin";
+        sourceAarch64Linux = checkedSources."aarch64-linux";
+        sourceX86_64Linux = checkedSources."x86_64-linux";
+        bottleArm64Sonoma = checkedBottles.arm64_sonoma;
+        bottleArm64Linux = checkedBottles.arm64_linux;
+        bottleX86_64Linux = checkedBottles.x86_64_linux;
+        platformArm64Sonoma = builtins.toJSON bottlePlatforms.arm64_sonoma;
+        platformArm64Linux = builtins.toJSON bottlePlatforms.arm64_linux;
+        platformX86_64Linux = builtins.toJSON bottlePlatforms.x86_64_linux;
+        releaseVersion = checkedVersion;
+        sourceRevision = checkedRevision;
+        nativeBuildInputs = with pkgs; [
+          coreutils
+          findutils
+          gawk
+          gnugrep
+          gzip
+          jq
+        ];
+      }
+      ''
+        set -euo pipefail
+        export LC_ALL=C
+
+        sourceFilename="${executableName}-$releaseVersion-source.tar.gz"
+        sourceUrl="https://github.com/${sourceRepository}/releases/download/v$releaseVersion/$sourceFilename"
+        work="$TMPDIR/release"
+        layout="$out/oci-layout"
+        blobs="$layout/blobs/sha256"
+        mkdir -p "$blobs" "$out/source" "$out/metadata" \
+          "$work/configs" "$work/manifests" "$work/descriptors" \
+          "$work/release-bottles" "$work/bottle-tags"
+
+        canonical_json() {
+          jq -cS "$@" | tr -d '\n'
+        }
+
+        validate_source() {
+          label="$1"
+          bundle="$2"
+          metadata="$bundle/source.json"
+          archive="$bundle/$sourceFilename"
+
+          if ! jq -e --arg filename "$sourceFilename" '
+            type == "object"
+            and keys == ["filename", "sha256"]
+            and .filename == $filename
+            and (.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+          ' "$metadata" >/dev/null; then
+            echo "$label source.json is malformed" >&2
+            return 1
+          fi
+          test -f "$archive"
+          claimed=$(jq -er '.sha256' "$metadata")
+          actual=$(sha256sum "$archive" | cut -d ' ' -f 1)
+          if test "$claimed" != "$actual"; then
+            echo "$label source archive digest mismatch" >&2
+            return 1
+          fi
+          printf '%s' "$actual"
+        }
+
+        darwin_source_sha=$(validate_source aarch64-darwin "$sourceAarch64Darwin")
+        arm_linux_source_sha=$(validate_source aarch64-linux "$sourceAarch64Linux")
+        x86_linux_source_sha=$(validate_source x86_64-linux "$sourceX86_64Linux")
+        if test "$darwin_source_sha" != "$x86_linux_source_sha" \
+          || test "$arm_linux_source_sha" != "$x86_linux_source_sha"; then
+          echo "native source archives are not byte-identical" >&2
+          exit 1
+        fi
+        cp "$sourceX86_64Linux/$sourceFilename" "$out/source/$sourceFilename"
+
+        make_platform() {
+          tag="$1"
+          input="$2"
+          expected_platform="$3"
+          tab_arch="$4"
+          metadata="$input/bottle.json"
+          expected_tar="${formulaName}--$releaseVersion.$tag.bottle.tar"
+          expected_gzip="$expected_tar.gz"
+
+          if ! jq -e \
+            --arg formula "${formulaName}" \
+            --arg version "$releaseVersion" \
+            --arg tag "$tag" \
+            --arg sourceFilename "$sourceFilename" \
+            --arg sourceSha "$x86_linux_source_sha" \
+            --arg sourceUrl "$sourceUrl" \
+            --arg expectedTar "$expected_tar" \
+            --arg expectedGzip "$expected_gzip" \
+            --argjson platform "$expected_platform" '
+              type == "object"
+              and keys == ["bottle", "formula", "ociPlatform", "schema", "source", "tag", "version"]
+              and .schema == 1
+              and .formula == $formula
+              and .version == $version
+              and .tag == $tag
+              and .ociPlatform == $platform
+              and (.source | type == "object" and keys == ["filename", "sha256", "url"])
+              and .source.filename == $sourceFilename
+              and .source.sha256 == $sourceSha
+              and .source.url == $sourceUrl
+              and (.bottle | type == "object" and keys == ["cellar", "filename", "installedSize", "sha256", "size", "uncompressedFilename", "uncompressedSha256", "uncompressedSize"])
+              and .bottle.cellar == "any_skip_relocation"
+              and .bottle.filename == $expectedGzip
+              and .bottle.uncompressedFilename == $expectedTar
+              and (.bottle.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+              and (.bottle.uncompressedSha256 | type == "string" and test("^[0-9a-f]{64}$"))
+              and (.bottle.size | type == "number" and . > 0)
+              and (.bottle.uncompressedSize | type == "number" and . > 0)
+              and (.bottle.installedSize | type == "number" and . > 0)
+            ' "$metadata" >/dev/null; then
+            echo "$tag bottle.json is malformed or mismatched" >&2
+            return 1
+          fi
+
+          compressed="$input/$expected_gzip"
+          uncompressed="$input/$expected_tar"
+          test -f "$compressed"
+          test -f "$uncompressed"
+
+          compressed_sha=$(sha256sum "$compressed" | cut -d ' ' -f 1)
+          uncompressed_sha=$(sha256sum "$uncompressed" | cut -d ' ' -f 1)
+          compressed_size=$(stat --format='%s' "$compressed")
+          uncompressed_size=$(stat --format='%s' "$uncompressed")
+          installed_size=$(jq -er '.bottle.installedSize' "$metadata")
+
+          test "$compressed_sha" = "$(jq -er '.bottle.sha256' "$metadata")"
+          test "$uncompressed_sha" = "$(jq -er '.bottle.uncompressedSha256' "$metadata")"
+          test "$compressed_size" = "$(jq -er '.bottle.size' "$metadata")"
+          test "$uncompressed_size" = "$(jq -er '.bottle.uncompressedSize' "$metadata")"
+          gzip --decompress --stdout "$compressed" | cmp - "$uncompressed"
+
+          layer_blob="$blobs/$compressed_sha"
+          if test -e "$layer_blob"; then
+            cmp "$compressed" "$layer_blob"
+          else
+            cp "$compressed" "$layer_blob"
+          fi
+
+          config="$work/configs/$tag.json"
+          canonical_json -n \
+            --argjson platform "$expected_platform" \
+            --arg diffId "sha256:$uncompressed_sha" \
+            '$platform + {rootfs:{type:"layers",diff_ids:[$diffId]}}' \
+            > "$config"
+          config_sha=$(sha256sum "$config" | cut -d ' ' -f 1)
+          config_size=$(stat --format='%s' "$config")
+          cp "$config" "$blobs/$config_sha"
+
+          tab_json=$(canonical_json -n --arg arch "$tab_arch" '{arch:$arch,runtime_dependencies:[]}')
+          annotations=$(canonical_json -n \
+            --arg refName "$releaseVersion.$tag" \
+            --arg bottleDigest "$compressed_sha" \
+            --arg bottleSize "$compressed_size" \
+            --arg installedSize "$installed_size" \
+            --arg tab "$tab_json" \
+            '{
+              "org.opencontainers.image.ref.name":$refName,
+              "sh.brew.bottle.digest":$bottleDigest,
+              "sh.brew.bottle.size":$bottleSize,
+              "sh.brew.bottle.installed_size":$installedSize,
+              "sh.brew.license":"GPL-3.0-only",
+              "sh.brew.tab":$tab,
+              "sh.brew.path_exec_files":"bin/pdf-sign"
+            }')
+
+          manifest="$work/manifests/$tag.json"
+          canonical_json -n \
+            --arg configDigest "sha256:$config_sha" \
+            --argjson configSize "$config_size" \
+            --arg layerDigest "sha256:$compressed_sha" \
+            --argjson layerSize "$compressed_size" \
+            --arg layerTitle "$expected_gzip" \
+            --argjson annotations "$annotations" \
+            '{
+              schemaVersion:2,
+              config:{
+                mediaType:"application/vnd.oci.image.config.v1+json",
+                digest:$configDigest,
+                size:$configSize
+              },
+              layers:[{
+                mediaType:"application/vnd.oci.image.layer.v1.tar+gzip",
+                digest:$layerDigest,
+                size:$layerSize,
+                annotations:{"org.opencontainers.image.title":$layerTitle}
+              }],
+              annotations:$annotations
+            }' > "$manifest"
+          manifest_sha=$(sha256sum "$manifest" | cut -d ' ' -f 1)
+          manifest_size=$(stat --format='%s' "$manifest")
+          cp "$manifest" "$blobs/$manifest_sha"
+
+          canonical_json -n \
+            --arg digest "sha256:$manifest_sha" \
+            --argjson size "$manifest_size" \
+            --argjson platform "$expected_platform" \
+            --argjson annotations "$annotations" \
+            '{
+              mediaType:"application/vnd.oci.image.manifest.v1+json",
+              digest:$digest,
+              size:$size,
+              platform:$platform,
+              annotations:$annotations
+            }' > "$work/descriptors/$tag.json"
+
+          canonical_json -n \
+            --arg tag "$tag" \
+            --arg sha256 "$compressed_sha" \
+            --arg manifestDigest "sha256:$manifest_sha" \
+            --argjson size "$compressed_size" \
+            --argjson installedSize "$installed_size" \
+            '{($tag):{
+              sha256:$sha256,
+              manifestDigest:$manifestDigest,
+              size:$size,
+              installedSize:$installedSize,
+              cellar:"any_skip_relocation"
+            }}' > "$work/release-bottles/$tag.json"
+
+          canonical_json -n \
+            --arg tag "$tag" \
+            --arg filename "$expected_gzip" \
+            --arg sha256 "$compressed_sha" \
+            --argjson installedSize "$installed_size" \
+            --argjson tab "$tab_json" \
+            '{($tag):{
+              filename:$filename,
+              local_filename:$filename,
+              sha256:$sha256,
+              tab:$tab,
+              path_exec_files:["bin/pdf-sign"],
+              installed_size:$installedSize
+            }}' > "$work/bottle-tags/$tag.json"
+        }
+
+        make_platform arm64_sonoma "$bottleArm64Sonoma" "$platformArm64Sonoma" arm64
+        make_platform arm64_linux "$bottleArm64Linux" "$platformArm64Linux" arm64
+        make_platform x86_64_linux "$bottleX86_64Linux" "$platformX86_64Linux" x86_64
+
+        descriptors=$(canonical_json -s '.' \
+          "$work/descriptors/arm64_sonoma.json" \
+          "$work/descriptors/arm64_linux.json" \
+          "$work/descriptors/x86_64_linux.json")
+        index_annotations=$(canonical_json -n \
+          --arg revision "$sourceRevision" \
+          --arg version "$releaseVersion" \
+          '{
+            "com.github.package.type":"homebrew_bottle",
+            "org.opencontainers.image.source":"https://github.com/${sourceRepository}",
+            "org.opencontainers.image.version":$version,
+            "org.opencontainers.image.licenses":"GPL-3.0-only",
+            "org.opencontainers.image.revision":$revision
+          }')
+        image_index="$work/image-index.json"
+        canonical_json -n \
+          --argjson manifests "$descriptors" \
+          --argjson annotations "$index_annotations" \
+          '{schemaVersion:2,manifests:$manifests,annotations:$annotations}' \
+          > "$image_index"
+        image_index_sha=$(sha256sum "$image_index" | cut -d ' ' -f 1)
+        image_index_size=$(stat --format='%s' "$image_index")
+        cp "$image_index" "$blobs/$image_index_sha"
+
+        canonical_json -n '{imageLayoutVersion:"1.0.0"}' > "$layout/oci-layout"
+        canonical_json -n \
+          --arg digest "sha256:$image_index_sha" \
+          --argjson size "$image_index_size" \
+          --arg version "$releaseVersion" \
+          '{
+            schemaVersion:2,
+            manifests:[{
+              mediaType:"application/vnd.oci.image.index.v1+json",
+              digest:$digest,
+              size:$size,
+              annotations:{"org.opencontainers.image.ref.name":$version}
+            }]
+          }' > "$layout/index.json"
+
+        release_bottles=$(canonical_json -s 'reduce .[] as $item ({}; . + $item)' \
+          "$work/release-bottles/arm64_sonoma.json" \
+          "$work/release-bottles/arm64_linux.json" \
+          "$work/release-bottles/x86_64_linux.json")
+        canonical_json -n \
+          --arg formula "${formulaName}" \
+          --arg version "$releaseVersion" \
+          --arg sourceFilename "$sourceFilename" \
+          --arg sourceSha "$x86_linux_source_sha" \
+          --arg repository "${ociRepository}" \
+          --arg indexDigest "sha256:$image_index_sha" \
+          --argjson bottles "$release_bottles" \
+          '{
+            schema:1,
+            formula:$formula,
+            version:$version,
+            source:{filename:$sourceFilename,sha256:$sourceSha},
+            oci:{repository:$repository,indexDigest:$indexDigest},
+            bottles:$bottles
+          }' > "$out/metadata/release.json"
+
+        bottle_tags=$(canonical_json -s 'reduce .[] as $item ({}; . + $item)' \
+          "$work/bottle-tags/arm64_sonoma.json" \
+          "$work/bottle-tags/arm64_linux.json" \
+          "$work/bottle-tags/x86_64_linux.json")
+        canonical_json -n \
+          --arg formula "${formulaName}" \
+          --arg version "$releaseVersion" \
+          --arg path "${formulaPath}" \
+          --arg desc "${description}" \
+          --argjson tags "$bottle_tags" \
+          '{($formula):{
+            formula:{
+              name:$formula,
+              pkg_version:$version,
+              path:$path,
+              tap_git_path:"Formula/pdf.rb",
+              desc:$desc,
+              license:"GPL-3.0-only",
+              homepage:"https://signed.page"
+            },
+            bottle:{
+              root_url:"${bottleRootUrl}",
+              cellar:"any_skip_relocation",
+              rebuild:0,
+              tags:$tags
+            }
+          }}' > "$out/metadata/pdf.bottle.json"
+
+        for blob in "$blobs"/*; do
+          name=$(basename "$blob")
+          if ! [[ "$name" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "malformed OCI blob name $name" >&2
+            exit 1
+          fi
+          actual=$(sha256sum "$blob" | cut -d ' ' -f 1)
+          if test "$actual" != "$name"; then
+            echo "OCI blob digest mismatch for $name" >&2
+            exit 1
+          fi
+        done
+
+        jq -e \
+          --arg version "$releaseVersion" \
+          --arg sourceSha "$x86_linux_source_sha" \
+          --arg indexDigest "sha256:$image_index_sha" '
+            .schema == 1
+            and .formula == "pdf"
+            and .version == $version
+            and .source.sha256 == $sourceSha
+            and .oci.repository == "ghcr.io/signed-page/tap/pdf"
+            and .oci.indexDigest == $indexDigest
+            and (.bottles | keys == ["arm64_linux", "arm64_sonoma", "x86_64_linux"])
+          ' "$out/metadata/release.json" >/dev/null
+      '';
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -47,7 +47,7 @@ rec {
 
       meta = with lib; {
         description = "Lightweight PDF signing tool with OpenPGP (GPG) and Sigstore (keyless OIDC) backends";
-        homepage = "https://github.com/0x77dev/pdf-sign";
+        homepage = "https://github.com/signed-page/pdf";
         license = licenses.gpl3Only;
         mainProgram = "pdf-sign";
         platforms = platforms.unix;
@@ -58,7 +58,7 @@ rec {
   );
 
   image = pkgs.dockerTools.streamLayeredImage {
-    name = "ghcr.io/0x77dev/pdf-sign";
+    name = "ghcr.io/signed-page/pdf";
 
     contents = [
       pdfSign
@@ -88,11 +88,394 @@ rec {
         "8080/tcp" = { };
       };
       Labels = {
-        "org.opencontainers.image.source" = "https://github.com/0x77dev/pdf-sign";
+        "org.opencontainers.image.source" = "https://github.com/signed-page/pdf";
         "org.opencontainers.image.description" =
           "Lightweight PDF signing with OpenPGP (GPG) and Sigstore (keyless OIDC)";
         "org.opencontainers.image.licenses" = "GPL-3.0-only";
       };
     };
   };
+
+  homebrew = import ./homebrew.nix {
+    inherit pkgs lib;
+  };
+
+  homebrewSourceTree = craneLib.path ../.;
+
+  homebrewCargoVendorDir = craneLib.vendorCargoDeps {
+    src = homebrewSourceTree;
+  };
+
+  homebrewSource = homebrew.mkSourceBundle {
+    src = homebrewSourceTree;
+    cargoVendorDir = homebrewCargoVendorDir;
+    inherit version;
+  };
+
+  homebrewPlatform =
+    ({
+      "aarch64-darwin" = {
+        bottleTag = "arm64_sonoma";
+        ociPlatform = {
+          architecture = "arm64";
+          os = "darwin";
+          "os.version" = "macOS 14";
+        };
+      };
+      "aarch64-linux" = {
+        bottleTag = "arm64_linux";
+        ociPlatform = {
+          architecture = "arm64";
+          os = "linux";
+        };
+      };
+      "x86_64-linux" = {
+        bottleTag = "x86_64_linux";
+        ociPlatform = {
+          architecture = "amd64";
+          os = "linux";
+        };
+      };
+    }).${pkgs.stdenv.hostPlatform.system} or null;
+
+  muslTarget =
+    if pkgs.stdenv.isLinux then
+      if pkgs.stdenv.hostPlatform.isAarch64 then
+        "aarch64-unknown-linux-musl"
+      else if pkgs.stdenv.hostPlatform.isx86_64 then
+        "x86_64-unknown-linux-musl"
+      else
+        throw "Homebrew Linux bottles support only aarch64 and x86_64"
+    else
+      null;
+
+  muslCraneLib =
+    if muslTarget == null then
+      null
+    else
+      craneLib.overrideToolchain (
+        rustPkgs:
+        rustPkgs.rust-bin.stable.latest.default.override {
+          targets = [ muslTarget ];
+        }
+      );
+
+  muslCC = if muslTarget == null then null else lib.getExe' pkgs.pkgsStatic.stdenv.cc "cc";
+
+  muslTargetEnv =
+    if muslTarget == null then
+      null
+    else
+      lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] muslTarget);
+
+  muslCcEnv =
+    if muslTarget == null then null else "CC_${builtins.replaceStrings [ "-" ] [ "_" ] muslTarget}";
+
+  muslCommonArgs =
+    if muslTarget == null then
+      null
+    else
+      commonArgs
+      // {
+        pname = "pdf-sign-homebrew";
+        CARGO_BUILD_TARGET = muslTarget;
+        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        "${muslCcEnv}" = muslCC;
+        "CARGO_TARGET_${muslTargetEnv}_LINKER" = muslCC;
+        nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+          pkgs.binutils
+          pkgs.file
+          pkgs.gnugrep
+        ];
+      };
+
+  muslCargoArtifacts = if muslTarget == null then null else muslCraneLib.buildDepsOnly muslCommonArgs;
+
+  portableLinux =
+    if muslTarget == null then
+      null
+    else
+      muslCraneLib.buildPackage (
+        muslCommonArgs
+        // {
+          cargoArtifacts = muslCargoArtifacts;
+          cargoExtraArgs = "--bin pdf-sign";
+          doCheck = false;
+          dontPatchELF = true;
+
+          postFixup = ''
+            binary="$out/bin/pdf-sign"
+            test -x "$binary"
+
+            case "${muslTarget}" in
+              aarch64-unknown-linux-musl)
+                architecture='ARM aarch64'
+                ;;
+              x86_64-unknown-linux-musl)
+                architecture='x86-64'
+                ;;
+              *)
+                echo "unsupported musl target ${muslTarget}" >&2
+                exit 1
+                ;;
+            esac
+
+            if ! ${pkgs.file}/bin/file "$binary" | grep -q "$architecture"; then
+              echo "Homebrew binary has the wrong ELF architecture" >&2
+              exit 1
+            fi
+            if ${pkgs.binutils}/bin/readelf -l "$binary" | grep -q 'Requesting program interpreter'; then
+              echo "Homebrew musl binary has a dynamic interpreter" >&2
+              exit 1
+            fi
+            if ${pkgs.binutils}/bin/readelf -d "$binary" 2>/dev/null \
+              | grep -E -q '(NEEDED|RPATH|RUNPATH)'; then
+              echo "Homebrew musl binary has dynamic dependencies or search paths" >&2
+              exit 1
+            fi
+            if grep -R -a -q '/nix/store' "$out"; then
+              echo "Homebrew musl output contains a Nix store reference" >&2
+              exit 1
+            fi
+          '';
+        }
+      );
+
+  portableDarwin =
+    if !(pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) then
+      null
+    else
+      pkgs.runCommand "pdf-sign-homebrew-darwin-${version}"
+        {
+          nativeBuildInputs = [
+            pkgs.coreutils
+            pkgs.darwin.cctools
+            pkgs.darwin.sigtool
+            pkgs.findutils
+            pkgs.gawk
+            pkgs.gnugrep
+            pkgs.gnused
+          ];
+        }
+        ''
+          set -euo pipefail
+          export LC_ALL=C
+
+          otool=${pkgs.darwin.cctools}/bin/otool
+          install_name_tool=${pkgs.darwin.cctools}/bin/install_name_tool
+          codesign=${lib.getExe' pkgs.darwin.sigtool "codesign"}
+          source_executable="${pdfSign}/bin/pdf-sign"
+          source_executable_dir=$(dirname "$source_executable")
+          executable="$out/bin/pdf-sign"
+          queue="$TMPDIR/dylib-queue"
+          processed="$TMPDIR/dylib-processed"
+          origins="$TMPDIR/dylib-origins"
+
+          mkdir -p "$out/bin" "$out/lib"
+          cp "$source_executable" "$executable"
+          chmod u+w,ugo+rx "$executable"
+          printf '%s\n' "$executable" > "$queue"
+          : > "$processed"
+          : > "$origins"
+          printf '%s\t%s\n' "$executable" "$source_executable" >> "$origins"
+
+          expand_path() {
+            value="$1"
+            owner="$2"
+            case "$value" in
+              @loader_path)
+                dirname "$owner"
+                ;;
+              @loader_path/*)
+                printf '%s/%s\n' "$(dirname "$owner")" "''${value#@loader_path/}"
+                ;;
+              @executable_path)
+                printf '%s\n' "$source_executable_dir"
+                ;;
+              @executable_path/*)
+                printf '%s/%s\n' "$source_executable_dir" "''${value#@executable_path/}"
+                ;;
+              /*)
+                printf '%s\n' "$value"
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          resolve_dependency() {
+            dependency="$1"
+            owner="$2"
+            source_owner="$3"
+            case "$dependency" in
+              @rpath/*)
+                suffix="''${dependency#@rpath/}"
+                while IFS= read -r search_path; do
+                  if expanded=$(expand_path "$search_path" "$source_owner"); then
+                    candidate="$expanded/$suffix"
+                    if test -e "$candidate"; then
+                      realpath "$candidate"
+                      return
+                    fi
+                  fi
+                done < <(
+                  "$otool" -l "$owner" | awk '
+                    $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+                    in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+                  '
+                )
+                ;;
+              *)
+                if expanded=$(expand_path "$dependency" "$source_owner") && test -e "$expanded"; then
+                  realpath "$expanded"
+                  return
+                fi
+                ;;
+            esac
+            echo "cannot resolve non-system dependency $dependency from $owner" >&2
+            return 1
+          }
+
+          while IFS= read -r binary; do
+            if grep -F -x -q "$binary" "$processed"; then
+              continue
+            fi
+            printf '%s\n' "$binary" >> "$processed"
+            source_owner=$(
+              awk -F '\t' -v destination="$binary" \
+                '$1 == destination { print $2; exit }' "$origins"
+            )
+            if test -z "$source_owner"; then
+              echo "missing source path for copied Mach-O $binary" >&2
+              exit 1
+            fi
+
+            while IFS= read -r dependency; do
+              test -n "$dependency" || continue
+              case "$dependency" in
+                /usr/lib/*|/System/Library/Frameworks/*)
+                  continue
+                  ;;
+              esac
+
+              resolved=$(resolve_dependency "$dependency" "$binary" "$source_owner")
+              case "$resolved" in
+                /usr/lib/*|/System/Library/Frameworks/*)
+                  "$install_name_tool" -change "$dependency" "$resolved" "$binary"
+                  continue
+                  ;;
+              esac
+
+              if test "$(basename "$resolved")" = "libiconv.2.dylib"; then
+                "$install_name_tool" -change "$dependency" "/usr/lib/libiconv.2.dylib" "$binary"
+                continue
+              fi
+
+              basename=$(basename "$resolved")
+              destination="$out/lib/$basename"
+              recorded=$(
+                awk -F '\t' -v destination="$destination" \
+                  '$1 == destination { print $2; exit }' "$origins"
+              )
+
+              if test -n "$recorded"; then
+                if test "$recorded" != "$resolved"; then
+                  echo "dylib basename collision for $basename" >&2
+                  exit 1
+                fi
+              else
+                cp -L "$resolved" "$destination"
+                chmod u+w "$destination"
+                printf '%s\t%s\n' "$destination" "$resolved" >> "$origins"
+                "$install_name_tool" -id "@loader_path/../lib/$basename" "$destination"
+                printf '%s\n' "$destination" >> "$queue"
+              fi
+
+              "$install_name_tool" \
+                -change "$dependency" "@loader_path/../lib/$basename" "$binary"
+            done < <(
+              "$otool" -L "$binary" \
+                | sed -e '1d' -e 's/^[[:space:]]*//' \
+                  -e 's/[[:space:]]*(compatibility version.*$//'
+            )
+          done < "$queue"
+
+          while IFS= read -r binary; do
+            while IFS= read -r rpath; do
+              "$install_name_tool" -delete_rpath "$rpath" "$binary"
+            done < <(
+              "$otool" -l "$binary" | awk '
+                $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+                in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+              ' | sort -u
+            )
+            min_os=$("$otool" -l "$binary" | awk '$1 == "minos" { print $2; exit }')
+            if test "$binary" = "$executable" && test "$min_os" != "14.0"; then
+              echo "Homebrew executable must target macOS 14.0, got $min_os" >&2
+              exit 1
+            fi
+            if "$otool" -L "$binary" | sed -e '1d' | grep -q '/nix/store' \
+              || "$otool" -l "$binary" | sed -e '1d' | grep -q '/nix/store'; then
+              echo "rewritten Mach-O still has a Nix store load command: $binary" >&2
+              exit 1
+            fi
+            while IFS= read -r dependency; do
+              test -n "$dependency" || continue
+              case "$dependency" in
+                /usr/lib/*|/System/Library/Frameworks/*|@loader_path/../lib/*)
+                  ;;
+                *)
+                  echo "unsupported Mach-O load command $dependency in $binary" >&2
+                  exit 1
+                  ;;
+              esac
+            done < <(
+              "$otool" -L "$binary" \
+                | sed -e '1d' -e 's/^[[:space:]]*//' \
+                  -e 's/[[:space:]]*(compatibility version.*$//'
+            )
+          done < "$processed"
+
+          while IFS= read -r binary; do
+            sed -i 's|/nix/store|/src/build|g' "$binary"
+          done < "$processed"
+
+          if grep -R -a -q '/nix/store' "$out"; then
+            echo "rewritten Darwin output contains a Nix store reference" >&2
+            exit 1
+          fi
+
+          find "$out/lib" -type f -print0 \
+            | sort -z \
+            | while IFS= read -r -d "" dylib; do
+                "$codesign" --force --sign - "$dylib"
+              done
+          "$codesign" --force --sign - "$executable"
+
+          if ! find "$out/lib" -type f -print -quit | grep -q .; then
+            rmdir "$out/lib"
+          fi
+        '';
+
+  portablePdfSign =
+    if pkgs.stdenv.isLinux then
+      portableLinux
+    else if pkgs.stdenv.isDarwin && pkgs.stdenv.hostPlatform.isAarch64 then
+      portableDarwin
+    else
+      throw "Homebrew bottles are unsupported on ${pkgs.stdenv.hostPlatform.system}";
+
+  homebrewBottle =
+    if homebrewPlatform == null then
+      throw "Homebrew bottles are unsupported on ${pkgs.stdenv.hostPlatform.system}"
+    else
+      homebrew.mkBottle {
+        pdfSign = portablePdfSign;
+        sourceBundle = homebrewSource;
+        inherit version;
+        inherit (homebrewPlatform) bottleTag ociPlatform;
+      };
+
+  mkHomebrewRelease = homebrew.mkRelease;
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -235,6 +235,7 @@ rec {
             fi
             if grep -R -a -q '/nix/store' "$out"; then
               echo "Homebrew musl output contains a Nix store reference" >&2
+              ${pkgs.binutils}/bin/strings "$binary" | grep '/nix/store/' >&2 || true
               exit 1
             fi
           '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -178,8 +178,9 @@ rec {
       commonArgs
       // {
         pname = "pdf-sign-homebrew";
+        cargoVendorDir = homebrewCargoVendorDir;
         CARGO_BUILD_TARGET = muslTarget;
-        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static --remap-path-prefix=${homebrewCargoVendorDir}=/cargo/vendor";
         "${muslCcEnv}" = muslCC;
         "CARGO_TARGET_${muslTargetEnv}_LINKER" = muslCC;
         nativeBuildInputs = commonArgs.nativeBuildInputs ++ [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -160,7 +160,7 @@ rec {
         }
       );
 
-  muslCC = if muslTarget == null then null else lib.getExe' pkgs.pkgsStatic.stdenv.cc "cc";
+  muslCC = if muslTarget == null then null else lib.getExe pkgs.pkgsStatic.stdenv.cc;
 
   muslTargetEnv =
     if muslTarget == null then


### PR DESCRIPTION
Adds reproducible three-platform Homebrew bottles, immutable GHCR OCI publication, App-authored Formula updates for signed-page/tap/pdf, and the v0.2.1 source release workflow.


Local verification: nix flake check; native arm64_sonoma bottle build, smoke test, linkage/signature/path checks, and deterministic rebuild; actionlint.

fixes #11 
fixes #128 