### PR TITLE
Prepare immutable v0.2.2 release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -313,16 +313,15 @@ jobs:
               --notes "Vendored corresponding source for pdf-sign $VERSION."
           fi
 
-          release_is_draft="$(
-            gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft'
-          )"
           mapfile -t asset_names < <(
             gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json assets --jq '.assets[].name' |
               LC_ALL=C sort
           )
           case "${#asset_names[@]}" in
             0)
-              if [[ "$release_is_draft" != "true" ]]; then
+              if [[ "$(
+                gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft'
+              )" != "true" ]]; then
                 echo "Published immutable release is missing the source archive" >&2
                 exit 1
               fi
@@ -363,7 +362,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "$release_is_draft" == "true" ]]; then
+          if [[ "$(gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft')" == "true" ]]; then
             gh release edit "$TAG" --repo "$SOURCE_REPOSITORY" --draft=false
           fi
           if [[ "$(gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft')" != "false" ]]; then

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -308,21 +308,24 @@ jobs:
             gh release create "$TAG" \
               --repo "$SOURCE_REPOSITORY" \
               --verify-tag \
+              --draft \
               --title "$TAG" \
               --notes "Vendored corresponding source for pdf-sign $VERSION."
           fi
 
-          if [[ "$(gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft')" != "false" ]]; then
-            echo "Refusing to publish into a draft release" >&2
-            exit 1
-          fi
-
+          release_is_draft="$(
+            gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft'
+          )"
           mapfile -t asset_names < <(
             gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json assets --jq '.assets[].name' |
               LC_ALL=C sort
           )
           case "${#asset_names[@]}" in
             0)
+              if [[ "$release_is_draft" != "true" ]]; then
+                echo "Published immutable release is missing the source archive" >&2
+                exit 1
+              fi
               gh release upload "$TAG" "$source_file" --repo "$SOURCE_REPOSITORY"
               ;;
             1)
@@ -338,11 +341,11 @@ jobs:
               ;;
           esac
 
-          mapfile -t published_assets < <(
+          mapfile -t release_assets < <(
             gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json assets --jq '.assets[].name' |
               LC_ALL=C sort
           )
-          if [[ "${#published_assets[@]}" -ne 1 || "${published_assets[0]}" != "$source_filename" ]]; then
+          if [[ "${#release_assets[@]}" -ne 1 || "${release_assets[0]}" != "$source_filename" ]]; then
             echo "Release asset set is not exactly the expected source archive" >&2
             exit 1
           fi
@@ -357,6 +360,14 @@ jobs:
           published_sha="$(sha256sum "$published_dir/$source_filename" | cut -d ' ' -f 1)"
           if [[ "$published_sha" != "$expected_source_sha" ]]; then
             echo "Existing release asset differs from the immutable Nix source archive" >&2
+            exit 1
+          fi
+
+          if [[ "$release_is_draft" == "true" ]]; then
+            gh release edit "$TAG" --repo "$SOURCE_REPOSITORY" --draft=false
+          fi
+          if [[ "$(gh release view "$TAG" --repo "$SOURCE_REPOSITORY" --json isDraft --jq '.isDraft')" != "false" ]]; then
+            echo "Source release did not become public" >&2
             exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-gpg"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-sigstore"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "pdf-sign-wasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "GPL-3.0-only"
 authors = ["Mykhailo Marynenko <mykhailo@0x77.dev>"]


### PR DESCRIPTION
Fixes the immutable-release publication order by creating a draft, uploading and validating the sole vendored source archive, then publishing. Bumps the workspace to v0.2.2 for a clean release namespace after GitHub permanently locked the empty v0.2.1 release before its post-publication upload.\n\nLocal verification: actionlint; cargo check --workspace.