### PR TITLE
Create Homebrew tap parent directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,6 +868,7 @@ jobs:
             echo "Homebrew tap path is already occupied" >&2
             exit 1
           fi
+          mkdir -p "$(dirname "$tap_path")"
           mv "$tap_checkout" "$tap_path"
           ln -s "$tap_path" "$tap_checkout"
           brew trust signed-page/tap


### PR DESCRIPTION
Creates Homebrew's per-owner Taps directory before moving the authenticated checkout into its canonical location.\n\nVerified: actionlint .github/workflows/ci.yml; git diff --check.