### PR TITLE
Preserve tap checkout authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,9 +868,18 @@ jobs:
             echo "Homebrew tap path is already occupied" >&2
             exit 1
           fi
+          auth_header="$(
+            git -C "$tap_checkout" config --get http.https://github.com/.extraheader
+          )"
+          if [[ "$auth_header" != AUTHORIZATION:* ]]; then
+            echo "Tap checkout is missing its App authentication header" >&2
+            exit 1
+          fi
           mkdir -p "$(dirname "$tap_path")"
           mv "$tap_checkout" "$tap_path"
           ln -s "$tap_path" "$tap_checkout"
+          git -C "$tap_path" config --local http.https://github.com/.extraheader "$auth_header"
+          unset auth_header
           brew trust signed-page/tap
 
           cd "$tap_path"


### PR DESCRIPTION
Copies actions/checkout's repository-local App authentication header into the moved canonical Homebrew tap checkout before pushing the Formula branch.\n\nVerified: actionlint .github/workflows/ci.yml; git diff --check.