### PR TITLE
Version Formula branches by rendered content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,8 +919,8 @@ jobs:
             exit 1
           fi
 
-          branch="release/pdf-v$VERSION"
           expected_blob="$(git hash-object Formula/pdf.rb)"
+          branch="release/pdf-v$VERSION-${expected_blob:0:12}"
           remote_listing="$RUNNER_TEMP/release-branch"
           set +e
           git ls-remote --exit-code --heads origin "refs/heads/$branch" > "$remote_listing"


### PR DESCRIPTION
Includes the rendered Formula blob ID in App-authored release branch names. An immutable release can now recover after a generated Formula is corrected without reusing a closed PR branch; identical retries still converge on one branch.\n\nVerified: actionlint .github/workflows/ci.yml; git diff --check.